### PR TITLE
Add support for Importing text collections

### DIFF
--- a/IMPORTING.md
+++ b/IMPORTING.md
@@ -1,0 +1,78 @@
+Which collections are useful for importing?
+
+## Image Collections
+
+In theory, you should be able to import any image collection. _In theory._
+
+```
+uv run dor catalog collection <collid> --class image
+```
+
+| COLLID         | TITLE                                                                         | RECORD COUNT |
+|----------------|-------------------------------------------------------------------------------|--------------|
+| apis           | Advanced Papyrological Information System (APIS UM)                           | 18,097       |
+| archivision3ic | Archivision Art Images                                                        | 15,315       |
+| baldwin1ic     | Chez Baldwin Writer's House Digital Collection                                | 1,481        |
+| bhl            | Bentley Historical Library: Bentley Image Bank                                | 35,123       |
+| bhl9ic         | Bentley Historical Library: Alfred Wilkinson Wilson Scrapbook, 1916-1921      | 450          |
+| bulgakov1ic    | Mikhail Bulgakov Digital Collection                                           | 614          |
+| ccs1ic         | Chinese Papercuts                                                             | 15           |
+| clark1ic       | UM Clark Library Maps                                                         | 1,239        |
+| dance1ic       | Pioneers of Chinese Dance                                                     | 1,512        |
+| dude1ic        | Duderstadt Photograph Archive                                                 | 3,878        |
+| hart           | History of Art, VRC Image Bank                                                | 392,109      |
+| herbvs         | Lewis David von Schweinitz, Icones Fungorum, University of Michigan Herbarium | 310          |
+| hussey1ic      | Alfred Hussey Collection: Japan's Constitution Slides                         | 17           |
+| hussey2ic      | Alfred Hussey Collection: Japan's Constitution Photo Album                    | 26           |
+| kelsey         | Kelsey Museum of Archaeology Art & Artifact Collection                        | 154,995      |
+| midaily1ic     | Michigan Daily Alumni Photographers                                           | 5,123        |
+| moaahbic       | Historic Buildings of Ann Arbor                                               | 209          |
+| scl            | Labadie Photograph Collection, University of Michigan                         | 1,596        |
+| sclalco        | Alco Locomotive Lantern Slides                                                | 371          |
+| sclib          | Special Collections Research Center Image Bank                                | 138          |
+| tinder         | David V. Tinder Collection of Michigan Photography                            | 66,470       |
+| umdvrc1ic      | College of Arts, Sciences, and Letters (UM-Dearborn)                          | 38,105       |
+| ummu           | Art, Architecture and Engineering Library                                     | 99,147       |
+| wcl1ic         | William L. Clements Library Image Bank                                        | 9,075        |
+| yhsic1         | Ypsilanti Historical Society Photo Archives                                   | 17,334       |
+
+## Text Collections
+
+Only the collections listed below can be imported via IIIF. 
+
+| COLLID                 | TITLE                                                                            | RECORD COUNT |
+|------------------------|----------------------------------------------------------------------------------|--------------|
+| adams                  | Samson Adams Papers, 1767-1794                                                   | 106          |
+| africanamer            | African American and African Diaspora Collection, 1729-1966 (bulk 1781-1865)     | 252          |
+| amjewess               | American Jewess                                                                  | 46           |
+| blydenburgh            | George and Marion Blydenburgh Papers, 1920-1934, 1998                            | 75           |
+| bosnia                 | Travels in Southeastern Europe                                                   | 137          |
+| campe                  | Elizabeth Camp Journals, 1819-1825                                               | 2            |
+| cliffe                 | Loftus Cliffe Papers, 1769-1784                                                  | 30           |
+| cme                    | Corpus of Middle English Prose and Verse                                         | 289          |
+| cohenaids              | Jon Cohen AIDS Research Collection                                               | 13375        |
+| dencos                 | Dental Cosmos                                                                    | 79           |
+| ethelsmyth             | Ethel Smyth Collection, 1910-1962                                                | 35           |
+| fortwayne              | Fort Wayne Indian Agency Collection, 1802-1815                                   | 3            |
+| fullerh                | Harriet DeGarmo Fuller Papers, 1852-1857                                         | 4            |
+| gage                   | Thomas Gage Papers, 1738-1807                                                    | 3331         |
+| gardnerfam             | Gardner Family Papers, 1776-1789                                                 | 10           |
+| greatbritainindiandept | Great Britain Indian Department Collection, 1753-1795                            | 52           |
+| holsteinfam            | Holstein Family Account and Commonplace Book, 1753-1831                          | 52           |
+| irving                 | Jacob Aemilius Irving Letterbooks, 1809-1816                                     | 52           |
+| jameshenry             | Henry James Family Correspondence, 1855-1865 (bulk 1859-1865)                    | 27           |
+| japanese               | Japanese Manuscript Collection, 1832-1861                                        | 12           |
+| kingfamily             | King Family Papers, 1844-1901                                                    | 52           |
+| leylandt               | Thomas Leyland Company Account Books, 1789-1793                                  | 2            |
+| marshallfam            | Humphry and Moses Marshall Papers, 1721-1863                                     | 216          |
+| mitchill               | Samuel Latham Mitchill Papers, 1801-1829                                         | 522          |
+| moajrnl                | Making of America Journal Articles                                               | 51729        |
+| potter                 | Ocha Potter Papers, 1898-2008                                                    | 9            |
+| pray                   | Digitized Selections from the George W. Pray Papers, 1844-1890                   | 80           |
+| rochester              | Rochester Ladies' Anti-Slavery Society Papers, 1848-1868                         | 103          |
+| shelburne              | William Petty, 1st Marquis of Lansdowne, 2nd Earl of Shelburne Papers, 1665-1885 | 2            |
+| stothert               | James Stothert Papers, 1784-1807                                                 | 45           |
+| thomas                 | Nathan M. Thomas Papers, 1818-1889                                               | 38           |
+| umregproc              | University of Michigan, Proceedings of the Board of Regents                      | 70           |
+| weldgrimke             | Weld-Grimké Family Papers, 1740-1930                                             | 7            |
+| wow                    | War of the Worlds Fan Mail                                                       | 1349         |

--- a/dor/config.py
+++ b/dor/config.py
@@ -1,9 +1,11 @@
+from sqlalchemy import Engine, event
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from importlib import resources
 
 import sqlalchemy
+from sqlalchemy import event
 
 from rich.console import Console
 
@@ -24,7 +26,7 @@ class Config:
     def _make_database_engine_url(self):
         url = sqlalchemy.engine.URL.create(
             drivername="sqlite",
-            database=str( self.database_path )
+            database=str( self.database_path ),
         )
         return url
 
@@ -36,9 +38,16 @@ class Config:
         cache_path.makedirs(exist_ok=True)
         return cache_path
     
-    def get_dlxs_image_api_url(self):
+    def get_dlxs_image_api_url(self, class_: str):
         hostname = os.getenv("DLXS_HOST", "quod.lib.umich.edu")
-        return f"https://{hostname}/cgi/i/image/api"
+        return f"https://{hostname}/cgi/{class_[0]}/{class_}/api"
 
 
 config = Config.from_env()
+
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()

--- a/dor/models/checksum.py
+++ b/dor/models/checksum.py
@@ -19,7 +19,7 @@ class Checksum(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     file_set_file_id: Mapped[int] = mapped_column(ForeignKey(
-        "catalog_object_file.id"), nullable=False, index=True)
+        "catalog_object_file.id", ondelete="CASCADE"), nullable=False, index=True)
 
     object_file: Mapped["ObjectFile"] = relationship(
-        back_populates="checksums")
+        back_populates="checksums", passive_deletes=True)

--- a/dor/models/collection.py
+++ b/dor/models/collection.py
@@ -19,9 +19,9 @@ collection_object_table = Table(
     "catalog_collection_object_membership",
     Base.metadata,
     Column("intellectual_object_id", ForeignKey(
-        "catalog_intellectual_object.id"), primary_key=True),
+        "catalog_intellectual_object.id", ondelete="CASCADE"), primary_key=True),
     Column("collection_id", ForeignKey(
-        "catalog_collection.id"), primary_key=True),
+        "catalog_collection.id", ondelete="CASCADE"), primary_key=True),
 )
 
 class Collection(Base):
@@ -36,5 +36,6 @@ class Collection(Base):
     description: Mapped[str] = mapped_column(String, nullable=True)
 
     objects: Mapped[List["IntellectualObject"]] = relationship(
-        secondary=collection_object_table, back_populates="collections"
+        secondary=collection_object_table, back_populates="collections",
+        cascade="all, delete"
     )

--- a/dor/models/intellectual_object.py
+++ b/dor/models/intellectual_object.py
@@ -57,12 +57,15 @@ class IntellectualObject(Base):
         lazy='selectin',
     )
 
-    object_files: Mapped[List["ObjectFile"]] = relationship(back_populates="intellectual_object", lazy="dynamic")
-    premis_events: Mapped[List["PremisEvent"]] = relationship(back_populates="intellectual_object")
-    revision: Mapped["CurrentRevision"] = relationship(back_populates="intellectual_object", uselist=False)
+    object_files: Mapped[List["ObjectFile"]] = relationship(back_populates="intellectual_object", lazy="dynamic", cascade="all, delete", passive_deletes=True)
+    premis_events: Mapped[List["PremisEvent"]] = relationship(
+        back_populates="intellectual_object", cascade="all, delete-orphan", passive_deletes=True)
+    revision: Mapped["CurrentRevision"] = relationship(
+        back_populates="intellectual_object", uselist=False, cascade="all, delete-orphan", passive_deletes=True)
 
     collections: Mapped[List["Collection"]] = relationship(
-        secondary=collection_object_table, back_populates="objects"
+        secondary=collection_object_table, back_populates="objects",
+        passive_deletes=True,
     )
 
     __table_args__ = (
@@ -93,7 +96,7 @@ class CurrentRevision(Base):
     intellectual_object_identifier: Mapped[uuid.UUID] = mapped_column(
         Uuid, unique=True, index=True)
     intellectual_object_id: Mapped[int] = mapped_column(ForeignKey(
-        "catalog_intellectual_object.id"), unique=False, nullable=True)
+        "catalog_intellectual_object.id", ondelete="CASCADE"), unique=False, nullable=True)
 
     intellectual_object: Mapped["IntellectualObject"] = relationship(
-        back_populates="revision")
+        back_populates="revision", passive_deletes=True)

--- a/dor/models/object_file.py
+++ b/dor/models/object_file.py
@@ -25,7 +25,7 @@ class ObjectFile(Base):
     last_fixity_check: Mapped[datetime] = mapped_column(
         DateTime(timezone=True))
     intellectual_object_id: Mapped[int] = mapped_column(
-        ForeignKey("catalog_intellectual_object.id"), index=True)
+        ForeignKey("catalog_intellectual_object.id", ondelete="CASCADE"), index=True)
 
     intellectual_object: Mapped["IntellectualObject"] = relationship(
         back_populates="object_files")

--- a/dor/models/premis_event.py
+++ b/dor/models/premis_event.py
@@ -23,9 +23,9 @@ class PremisEvent(Base):
     linking_agent: Mapped[str] = mapped_column(String, nullable=True)
     # foreign key to file set file
     intellectual_object_id: Mapped[int] = mapped_column(ForeignKey(
-        "catalog_intellectual_object.id"), nullable=True, index=True)
+        "catalog_intellectual_object.id", ondelete="CASCADE"), nullable=True, index=True)
     object_file_id: Mapped[int] = mapped_column(ForeignKey(
-        "catalog_object_file.id"), nullable=True, index=True)
+        "catalog_object_file.id", ondelete="CASCADE"), nullable=True, index=True)
 
     intellectual_object: Mapped["IntellectualObject"] = relationship(
         back_populates="premis_events")


### PR DESCRIPTION
* add support for importing a select list of text collections
* added `IMPORTING.md` with a list of image and text collections so you don't have to consult the A-Z list
* with text class support, the `collection` command now has a required `--image` or `--text` option
* when you re-import a collection, the previous data for that collection is deleted first

**IMPORTANT!** this changes the datatabase schema, so you'll need to run `uv run dor catalog initialize` again

