### PR TITLE
Add file sets pagination to object detail page

### DIFF
--- a/dor/services/catalog.py
+++ b/dor/services/catalog.py
@@ -73,7 +73,8 @@ class CollectionsManager(Manager):
 class FileSetsManager(Manager):
 
     def find(
-        self, session: Session,
+        self,
+        session: Session,
         object_identifier: UUID,
         start: int = 0,
         limit: int = 100

--- a/dor/services/catalog.py
+++ b/dor/services/catalog.py
@@ -6,6 +6,7 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.orm import Session
 
 from dor.models.collection import Collection
+from dor.models.file_set import FileSet
 from dor.models.intellectual_object import CurrentRevision, IntellectualObject
 from dor.utils import Page
 
@@ -27,7 +28,7 @@ class Manager:
             total_items=total_items,
             offset=start,
             limit=limit,
-            items=items
+            items=list(items)
         )
 
 
@@ -67,12 +68,30 @@ class CollectionsManager(Manager):
         item = session.execute(query).scalar_one()
         return item
 
+
+@dataclass(kw_only=True)
+class FileSetsManager(Manager):
+
+    def find(
+        self, session: Session,
+        object_identifier: UUID,
+        start: int = 0,
+        limit: int = 100
+    ):
+        query = select(FileSet) \
+            .join(IntellectualObject) \
+            .join(CurrentRevision) \
+            .filter(IntellectualObject.identifier==object_identifier)
+        return self._find(session=session, query=query, start=start, limit=limit)
+
 @dataclass
 class Catalog:
     objects: ObjectsManager
     collections: CollectionsManager
+    file_sets: FileSetsManager
 
 catalog = Catalog(
     objects=ObjectsManager(),
-    collections=CollectionsManager()
+    collections=CollectionsManager(),
+    file_sets=FileSetsManager()
 )


### PR DESCRIPTION
This PR aims to resolve [DOR-82](https://mlit.atlassian.net/browse/DOR-82). It adds pagination to the filesets list. There might be other ways to do this via the `object`; this is one strategy that prevents fetching all the data.

Not sure exactly how we'll implement pagination in the template, but this is what I threw together for testing:
```
# object.html

{% for file_set in file_sets_page.items %}
<p>{{ file_set.identifier }} - {{ file_set.title }}</p>
{% endfor %}

<p>{{ file_sets_page.total_items }} items</p>

{% for page_index in range(file_sets_page.total_pages) %}
<p>
    <a href="/admin/console/objects/{{ object.identifier }}?file_set_start={{ page_index * 10 }}">
        Page {{ page_index + 1 }}
    </a>
</p>
{% endfor %}
```