### PR TITLE
Add query, path, and template placeholder for event detail (DOR-87)

### DIFF
--- a/dor/entrypoints/api/console.py
+++ b/dor/entrypoints/api/console.py
@@ -96,3 +96,16 @@ async def get_object(
     return templates.TemplateResponse(
         request=request, name="object.html", context=context
     )
+
+
+@console_router.get("/events/{identifier}")
+async def get_event(
+    request: Request, identifier: UUID, session=Depends(get_db_session)
+) -> HTMLResponse:
+    event = catalog.events.get(session=session, identifier=identifier)
+    if not event:
+        return HTMLResponse(status_code=status.HTTP_404_NOT_FOUND)
+
+    return templates.TemplateResponse(
+        request=request, name="event.html", context={"event": event}
+    )

--- a/dor/services/catalog.py
+++ b/dor/services/catalog.py
@@ -9,8 +9,8 @@ from dor.models.collection import Collection
 from dor.models.fileset import Fileset
 from dor.models.intellectual_object import CurrentRevision, IntellectualObject
 from dor.models.premis_event import PremisEvent
-
 from dor.utils import Page
+
 
 def calculate_totals_query(query):
     subquery_alias = query.alias("count_query")

--- a/dor/services/catalog.py
+++ b/dor/services/catalog.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 from dor.models.collection import Collection
 from dor.models.fileset import Fileset
 from dor.models.intellectual_object import CurrentRevision, IntellectualObject
+from dor.models.premis_event import PremisEvent
+
 from dor.utils import Page
 
 def calculate_totals_query(query):
@@ -105,14 +107,29 @@ class FilesetsManager(Manager):
         return self._find(session=session, query=query, start=start, limit=limit)
 
 
+@dataclass(kw_only=True)
+class EventsManager():
+
+    def get(self, session: Session, identifier: UUID) -> PremisEvent | None:
+        query = select(PremisEvent).filter_by(identifier=identifier)
+
+        try:
+            event = session.execute(query).scalar_one()
+            return event
+        except sqlalchemy.exc.NoResultFound:
+            return None
+
+
 @dataclass
 class Catalog:
     objects: ObjectsManager
     collections: CollectionsManager
     filesets: FilesetsManager
+    events: EventsManager
 
 catalog = Catalog(
     objects=ObjectsManager(),
     collections=CollectionsManager(),
-    filesets=FilesetsManager()
+    filesets=FilesetsManager(),
+    events=EventsManager()
 )

--- a/dor/services/catalog.py
+++ b/dor/services/catalog.py
@@ -112,10 +112,8 @@ class EventsManager():
 
     def get(self, session: Session, identifier: UUID) -> PremisEvent | None:
         query = select(PremisEvent).filter_by(identifier=identifier)
-
         try:
-            event = session.execute(query).scalar_one()
-            return event
+            return session.execute(query).scalar_one()
         except sqlalchemy.exc.NoResultFound:
             return None
 

--- a/templates/event.html
+++ b/templates/event.html
@@ -3,4 +3,11 @@
 {% block content %}
 <p class="subtle-heading">Event</p>
 <h1 class="mb-2">{{ event.identifier }}</h1>
+
+{% if event.intellectual_object %}
+<p>Object Identifier</p>
+<a href="/admin/console/objects/{{ event.intellectual_object.identifier }}">
+  {{ event.intellectual_object.identifier }}
+</a>
+{% endif %}
 {% endblock %}

--- a/templates/event.html
+++ b/templates/event.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<p class="subtle-heading">Event</p>
+<h1 class="mb-2">{{ event.identifier }}</h1>
+{% endblock %}


### PR DESCRIPTION
This PR aims to partially resolve [DOR-87](https://mlit.atlassian.net/jira/software/projects/DOR/boards/93?jql=parent%20%3D%20DOR-81&selectedIssue=DOR-87). It adds an `EventManager` for making database queries for events, a console path for an event, and the beginnings of an event detail template.