### PR TITLE
Add pagination for objects and filesets

### DIFF
--- a/dor/entrypoints/api/console.py
+++ b/dor/entrypoints/api/console.py
@@ -40,7 +40,8 @@ async def get_objects(
         start=start,
         object_type=object_type,
         alt_identifier=alt_identifier,
-        collection_alt_identifier=collection_alt_identifier
+        collection_alt_identifier=collection_alt_identifier,
+        limit=10
     )
 
     object_types = catalog.objects.get_distinct_types(session)

--- a/dor/utils.py
+++ b/dor/utils.py
@@ -88,6 +88,9 @@ class Page:
         self.total_pages = math.ceil(self.total_items / self.limit)
         if self.offset - self.limit >= 0:
             self.previous_offset = self.offset - self.limit
+        elif self.offset > 0:
+            self.previous_offset = 0
+
         if self.offset + self.limit < self.total_items:
             self.next_offset = self.offset + self.limit
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -96,7 +96,7 @@ h3 {
   flex-direction: column;
 }
 
-input[type="text"] {
+input[type="text"], input[type="number"] {
   border: solid 1px var(--color-neutral-200);
   padding: 0.5rem 0.75rem;
   border-radius: 2px;
@@ -321,6 +321,10 @@ table.m-table {
 .mt-2 { margin-top: 2rem; }
 .mb-1 { margin-bottom: 1rem; }
 .mb-2 { margin-bottom: 2rem; }
+.ml-1 { margin-left: 1rem; }
+.ml-2 { margin-left: 2rem; }
+.mr-1 { margin-right: 1rem; }
+.mr-2 { margin-right: 2rem; }
 
 /* Padding */
 .p-0 { padding: 0; }

--- a/templates/macros/pagination.html
+++ b/templates/macros/pagination.html
@@ -35,7 +35,7 @@
     <div class="input-group-inline" style="float: right">
       <div class="input-container mr-1">
         <span>
-          Go to page&nbsp;
+          Go to page
           <input
             type="number"
             id="{{ page_number_input_id }}"

--- a/templates/macros/pagination.html
+++ b/templates/macros/pagination.html
@@ -10,7 +10,7 @@
 ) %}
 <div id="pagination">
   <div class="input-group-inline">
-    <div class="input-group-inline" style="float: left">
+    <div class="input-group-inline">
       <div class="input-container mr-1">
         <button
           id="{{ previous_button_id }}"
@@ -32,7 +32,7 @@
         </button>
       </div>
     </div>
-    <div class="input-group-inline" style="float: right">
+    <div class="input-group-inline">
       <div class="input-container mr-1">
         <span>
           Go to page

--- a/templates/macros/pagination.html
+++ b/templates/macros/pagination.html
@@ -1,0 +1,57 @@
+{% macro pagination(
+    page_index,
+    num_pages,
+    previous_button_id,
+    previous_button_disabled,
+    next_button_id,
+    next_button_disabled,
+    page_number_input_id,
+    go_button_id
+) %}
+<div id="pagination">
+  <div class="input-group-inline">
+    <div class="input-group-inline" style="float: left">
+      <div class="input-container mr-1">
+        <button
+          id="{{ previous_button_id }}"
+          class="button--ghost"
+          {% if previous_button_disabled %} disabled {% endif %}
+        >
+          <span class="material-symbols-rounded">chevron_backward</span>
+          <span>Previous</span>
+        </button>
+      </div>
+      <div class="input-container">
+        <button
+          id="{{ next_button_id }}"
+          class="button--ghost"
+          {% if next_button_disabled %} disabled {% endif %}
+        >
+          <span>Next</span>
+          <span class="material-symbols-rounded">chevron_right</span>
+        </button>
+      </div>
+    </div>
+    <div class="input-group-inline" style="float: right">
+      <div class="input-container mr-1">
+        <span>
+          Go to page&nbsp;
+          <input
+            type="number"
+            id="{{ page_number_input_id }}"
+            name="number"
+            min="1"
+            max="{{ num_pages }}"
+            value="{{ page_index }}"
+            step="1"
+          />
+          of {{ num_pages }}
+        </span>
+      </div>
+      <div class="input-container">
+        <button id="{{ go_button_id }}" class="button--primary">Go</button>
+      </div>
+    </div>
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -12,7 +12,7 @@
   go_button_id='pageGoButton' + id_suffix
 ) }}
 <script>
-  const urlString = "{{ url }}";
+  const urlString = "{{ url | safe }}";
   const limit = Number("{{ page.limit }}");
   const total = Number("{{ page.total_pages }}");
   const idSuffix = "{{ id_suffix }}";

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -18,28 +18,23 @@
   const startKey = "{{ start_key }}";
 
   const urlObj = new URL(urlString);
-  const path = urlObj.pathname;
   const searchParams = new URLSearchParams(urlObj.search);
   const currentStart = Number(searchParams.get(startKey) ?? 0);
 
-  function goTo(path, searchParams) {
-    window.location.href = path + "?" + searchParams.toString();
-  }
-
   document.getElementById("pagePreviousButton" + idSuffix).onclick = function() {
     searchParams.set(startKey, currentStart - limit);
-    goTo(path, searchParams);
+    location.assign("?" + searchParams.toString())
   };
 
   document.getElementById("pageNextButton" + idSuffix).onclick = function() {
     searchParams.set(startKey, currentStart + limit);
-    goTo(path, searchParams);
+    location.assign("?" + searchParams.toString())
   };
 
   document.getElementById("pageGoButton" + idSuffix).onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput" + idSuffix).value;
     searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
-    goTo(path, searchParams);
+    location.assign("?" + searchParams.toString())
   };
 </script>
 {%- endmacro %}

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -14,6 +14,8 @@
 <script>
   const urlString = "{{ url | safe }}";
   const limit = Number("{{ page.limit }}");
+  const previousOffset = Number("{{ page.previous_offset }}")
+  const nextOffset = Number("{{ page.next_offset }}")
   const idSuffix = "{{ id_suffix }}";
   const startKey = "{{ start_key }}";
 
@@ -22,12 +24,12 @@
   const currentStart = Number(searchParams.get(startKey) ?? 0);
 
   document.getElementById("pagePreviousButton" + idSuffix).onclick = function() {
-    searchParams.set(startKey, currentStart - limit);
+    searchParams.set(startKey, previousOffset);
     location.assign("?" + searchParams.toString());
   };
 
   document.getElementById("pageNextButton" + idSuffix).onclick = function() {
-    searchParams.set(startKey, currentStart + limit);
+    searchParams.set(startKey, nextOffset);
     location.assign("?" + searchParams.toString());
   };
 

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -1,0 +1,46 @@
+{% from 'macros/pagination.html' import pagination %}
+{% macro start_pagination(page, id_suffix, url, start_key) %}
+
+{{ pagination(
+  page_index=page.index,
+  num_pages=page.total_pages,
+  previous_button_id='pagePreviousButton' + id_suffix,
+  previous_button_disabled=page.previous_offset == -1,
+  next_button_id='pageNextButton' + id_suffix,
+  next_button_disabled=page.next_offset == -1,
+  page_number_input_id='pageNumberInput' + id_suffix,
+  go_button_id='pageGoButton' + id_suffix
+) }}
+<script>
+  const urlString = "{{ url }}";
+  const limit = Number("{{ page.limit }}");
+  const total = Number("{{ page.total_pages }}");
+  const idSuffix = "{{ id_suffix }}";
+  const startKey = "{{ start_key }}";
+
+  const urlObj = new URL(urlString);
+  const path = urlObj.pathname;
+  const searchParams = new URLSearchParams(urlObj.search);
+  const currentStart = Number(searchParams.get(startKey) ?? 0);
+
+  function goTo(path, searchParams) {
+    window.location.href = path + "?" + searchParams.toString();
+  }
+
+  document.getElementById("pagePreviousButton" + idSuffix).onclick = function() {
+    searchParams.set(startKey, currentStart - limit);
+    goTo(path, searchParams);
+  };
+
+  document.getElementById("pageNextButton" + idSuffix).onclick = function() {
+    searchParams.set(startKey, currentStart + limit);
+    goTo(path, searchParams);
+  };
+
+  document.getElementById("pageGoButton" + idSuffix).onclick = function() {
+    const pageNumValue = document.getElementById("pageNumberInput" + idSuffix).value;
+    searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
+    goTo(path, searchParams);
+  };
+</script>
+{%- endmacro %}

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -23,18 +23,18 @@
 
   document.getElementById("pagePreviousButton" + idSuffix).onclick = function() {
     searchParams.set(startKey, currentStart - limit);
-    location.assign("?" + searchParams.toString())
+    location.assign("?" + searchParams.toString());
   };
 
   document.getElementById("pageNextButton" + idSuffix).onclick = function() {
     searchParams.set(startKey, currentStart + limit);
-    location.assign("?" + searchParams.toString())
+    location.assign("?" + searchParams.toString());
   };
 
   document.getElementById("pageGoButton" + idSuffix).onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput" + idSuffix).value;
     searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
-    location.assign("?" + searchParams.toString())
+    location.assign("?" + searchParams.toString());
   };
 </script>
 {%- endmacro %}

--- a/templates/macros/start_pagination.html
+++ b/templates/macros/start_pagination.html
@@ -14,7 +14,6 @@
 <script>
   const urlString = "{{ url | safe }}";
   const limit = Number("{{ page.limit }}");
-  const total = Number("{{ page.total_pages }}");
   const idSuffix = "{{ id_suffix }}";
   const startKey = "{{ start_key }}";
 

--- a/templates/object.html
+++ b/templates/object.html
@@ -148,13 +148,11 @@
   const currentStart = Number(searchParams.get("fileset_start") ?? 0);
 
   document.getElementById('pagePreviousButton').onclick = function() {
-    if (currentStart <= 0) return;
     searchParams.set("fileset_start", currentStart - limit > 0 ? currentStart - limit : 0);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageNextButton').onclick = function() {
-    if (currentStart + limit > total) return;
     searchParams.set("fileset_start", currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();
   };

--- a/templates/object.html
+++ b/templates/object.html
@@ -1,4 +1,4 @@
-{% from 'macros/pagination.html' import pagination %}
+{% from 'macros/start_pagination.html' import start_pagination %}
 {% extends "base.html" %}
 
 {% block content %}
@@ -119,55 +119,12 @@
 </details>
 {% endfor %}
 </div>
-{{ pagination(
-  page_index=filesets_page.index,
-  num_pages=filesets_page.total_pages,
-  previous_button_id='pagePreviousButton',
-  previous_button_disabled=filesets_page.previous_offset == -1,
-  next_button_id='pageNextButton',
-  next_button_disabled=filesets_page.next_offset == -1,
-  page_number_input_id='pageNumberInput',
-  go_button_id='pageGoButton'
+{{ start_pagination(
+  page=filesets_page,
+  url=request.url,
+  id_suffix="Filesets",
+  start_key="fileset_start"
 ) }}
-<div
-  id="paginationData"
-  data-url="{{ request.url }}"
-  data-limit="{{ filesets_page.limit }}"
-  data-total="{{ filesets_page.total_items }}"
->
-</div>
-<script>
-  const dataElem = document.getElementById("paginationData");
-  const urlString = dataElem.dataset.url;
-  const limit = Number(dataElem.dataset.limit);
-  const total = Number(dataElem.dataset.total);
-
-  const url = new URL(urlString);
-  const path = url.pathname;
-  const searchParams = new URLSearchParams(url.search);
-  const startKey = "fileset_start";
-  const currentStart = Number(searchParams.get(startKey) ?? 0);
-
-  function goTo(path, searchParams) {
-    window.location.href = path + "?" + searchParams.toString();
-  }
-
-  document.getElementById("pagePreviousButton").onclick = function() {
-    searchParams.set(startKey, currentStart - limit);
-    goTo(path, searchParams);
-  };
-
-  document.getElementById("pageNextButton").onclick = function() {
-    searchParams.set(startKey, currentStart + limit);
-    goTo(path, searchParams);
-  };
-
-  document.getElementById("pageGoButton").onclick = function() {
-    const pageNumValue = document.getElementById("pageNumberInput").value;
-    searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
-    goTo(path, searchParams);
-  };
-</script>
 <h2>Actions</h2>
 <button class="button button--primary">Download object</button>
 <button class="button button--delete">Delete object</button>

--- a/templates/object.html
+++ b/templates/object.html
@@ -76,6 +76,7 @@
 <p>A list of the data source files in this object. Select one to view details about the entire fileset associated with it, including service files, descriptor files, and event metadata. </p>
 <!--Add the source file loop-->
 <div class="mb-1">
+<p>Showing {{ filesets_page.range }} of {{ filesets_page.total_items }} filesets</p>
 {% for fileset in filesets_page.items %}
 <details>
   <summary class="mono">source file name <span class="order-label">{{ fileset.order_label }}</span></summary>

--- a/templates/object.html
+++ b/templates/object.html
@@ -1,3 +1,4 @@
+{% from 'macros/pagination.html' import pagination %}
 {% extends "base.html" %}
 
 {% block content %}
@@ -118,55 +119,25 @@
 </details>
 {% endfor %}
 </div>
-<div id="pagination">
-  <div id="data" data-url="{{ request.url }}" data-limit="{{ filesets_page.limit }}" data-total="{{ filesets_page.total_items }}"></div>
-  <div class="input-group-inline">
-    <div class="input-group-inline" style="float: left">
-      <div class="input-container mr-1">
-        <button
-          id="pagePreviousButton"
-          class="button--ghost"
-          {% if filesets_page.previous_offset == -1 %} disabled {% endif %}
-        >
-          <span class="material-symbols-rounded">chevron_backward</span>
-          <span>Previous</span>
-        </button>
-      </div>
-      <div class="input-container">
-        <button
-          id="pageNextButton"
-          class="button--ghost"
-          {% if filesets_page.next_offset == -1 %} disabled {% endif %}
-        >
-          <span>Next</span>
-          <span class="material-symbols-rounded">chevron_right</span>
-        </button>
-      </div>
-    </div>
-    <div class="input-group-inline" style="float: right">
-      <div class="input-container mr-1">
-        <span>
-          Go to page&nbsp;
-          <input
-            type="number"
-            id="pageNumberInput"
-            name="number"
-            min="1"
-            max="{{ filesets_page.total_pages }}"
-            value="{{ filesets_page.index }}"
-            step="1"
-          />
-          of {{ filesets_page.total_pages }}
-        </span>
-      </div>
-      <div class="input-container">
-        <button id="pageGoButton" class="button--primary">Go</button>
-      </div>
-    </div>
-  </div>
+<div
+  id="pagination-data"
+  data-url="{{ request.url }}"
+  data-limit="{{ filesets_page.limit }}"
+  data-total="{{ filesets_page.total_items }}"
+>
 </div>
+{{ pagination(
+  page_index=filesets_page.index,
+  num_pages=filesets_page.total_pages,
+  previous_button_id='pagePreviousButton',
+  previous_button_disabled=filesets_page.previous_offset == -1,
+  next_button_id='pageNextButton',
+  next_button_disabled=filesets_page.next_offset == -1,
+  page_number_input_id='pageNumberInput',
+  go_button_id='pageGoButton'
+) }}
 <script>
-  const dataElem = document.getElementById("data");
+  const dataElem = document.getElementById("pagination-data");
   const urlString = dataElem.dataset.url;
   const limit = Number(dataElem.dataset.limit);
   const total = Number(dataElem.dataset.total);
@@ -175,8 +146,6 @@
   const path = url.pathname;
   const searchParams = new URLSearchParams(url.search);
   const currentStart = Number(searchParams.get("fileset_start") ?? 0);
-  console.log(searchParams.toString())
-  console.log(currentStart)
 
   document.getElementById('pagePreviousButton').onclick = function() {
     if (currentStart <= 0) return;
@@ -198,8 +167,6 @@
     window.location.href = path + "?" + searchParams.toString()
   };
 </script>
-
-
 <h2>Actions</h2>
 <button class="button button--primary">Download object</button>
 <button class="button button--delete">Delete object</button>

--- a/templates/object.html
+++ b/templates/object.html
@@ -164,7 +164,7 @@
 
   document.getElementById("pageGoButton").onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
-    searchParams.set(startKey, limit * (Number(pageNumValue) - 1))
+    searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
     goTo(path, searchParams);
   };
 </script>

--- a/templates/object.html
+++ b/templates/object.html
@@ -145,22 +145,23 @@
   const url = new URL(urlString);
   const path = url.pathname;
   const searchParams = new URLSearchParams(url.search);
-  const currentStart = Number(searchParams.get("fileset_start") ?? 0);
+  const startKey = "fileset_start";
+  const currentStart = Number(searchParams.get(startKey) ?? 0);
 
   document.getElementById('pagePreviousButton').onclick = function() {
-    searchParams.set("fileset_start", currentStart - limit > 0 ? currentStart - limit : 0);
+    searchParams.set(startKey, currentStart - limit);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageNextButton').onclick = function() {
-    searchParams.set("fileset_start", currentStart + limit);
+    searchParams.set(startKey, currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageGoButton').onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
     const start = limit * (Number(pageNumValue) - 1);
-    searchParams.set("fileset_start", start)
+    searchParams.set(startKey, start)
     window.location.href = path + "?" + searchParams.toString()
   };
 </script>

--- a/templates/object.html
+++ b/templates/object.html
@@ -154,7 +154,6 @@
   };
 
   document.getElementById('pageNextButton').onclick = function() {
-    console.log("next click")
     if (currentStart + limit > total) return;
     searchParams.set("fileset_start", currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();

--- a/templates/object.html
+++ b/templates/object.html
@@ -75,8 +75,10 @@
 <h2>Source Files</h2>
 <p>A list of the data source files in this object. Select one to view details about the entire fileset associated with it, including service files, descriptor files, and event metadata. </p>
 <!--Add the source file loop-->
+<div class="mb-1">
+{% for fileset in filesets_page.items %}
 <details>
-  <summary class="mono">source file name <span class="order-label">#</span></summary>
+  <summary class="mono">source file name <span class="order-label">{{ fileset.order_label }}</span></summary>
   <div class="details-contents-wrapper">
     <h3>About this fileset</h3>
     <dl>
@@ -113,6 +115,89 @@
     <button class="button button--secondary">Download fileset</button>
   </div>
 </details>
+{% endfor %}
+</div>
+<div id="pagination">
+  <div id="data" data-url="{{ request.url }}" data-limit="{{ filesets_page.limit }}" data-total="{{ filesets_page.total_items }}"></div>
+  <div class="input-group-inline">
+    <div class="input-group-inline" style="float: left">
+      <div class="input-container mr-1">
+        <button
+          id="pagePreviousButton"
+          class="button--ghost"
+          {% if filesets_page.previous_offset == -1 %} disabled {% endif %}
+        >
+          <span class="material-symbols-rounded">chevron_backward</span>
+          <span>Previous</span>
+        </button>
+      </div>
+      <div class="input-container">
+        <button
+          id="pageNextButton"
+          class="button--ghost"
+          {% if filesets_page.next_offset == -1 %} disabled {% endif %}
+        >
+          <span>Next</span>
+          <span class="material-symbols-rounded">chevron_right</span>
+        </button>
+      </div>
+    </div>
+    <div class="input-group-inline" style="float: right">
+      <div class="input-container mr-1">
+        <span>
+          Go to page&nbsp;
+          <input
+            type="number"
+            id="pageNumberInput"
+            name="number"
+            min="1"
+            max="{{ filesets_page.total_pages }}"
+            value="{{ filesets_page.index }}"
+            step="1"
+          />
+          of {{ filesets_page.total_pages }}
+        </span>
+      </div>
+      <div class="input-container">
+        <button id="pageGoButton" class="button--primary">Go</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  const dataElem = document.getElementById("data");
+  const urlString = dataElem.dataset.url;
+  const limit = Number(dataElem.dataset.limit);
+  const total = Number(dataElem.dataset.total);
+
+  const url = new URL(urlString);
+  const path = url.pathname;
+  const searchParams = new URLSearchParams(url.search);
+  const currentStart = Number(searchParams.get("fileset_start") ?? 0);
+  console.log(searchParams.toString())
+  console.log(currentStart)
+
+  document.getElementById('pagePreviousButton').onclick = function() {
+    if (currentStart <= 0) return;
+    searchParams.set("fileset_start", currentStart - limit > 0 ? currentStart - limit : 0);
+    window.location.href = path + "?" + searchParams.toString();
+  };
+
+  document.getElementById('pageNextButton').onclick = function() {
+    console.log("next click")
+    if (currentStart + limit > total) return;
+    searchParams.set("fileset_start", currentStart + limit);
+    window.location.href = path + "?" + searchParams.toString();
+  };
+
+  document.getElementById('pageGoButton').onclick = function() {
+    const pageNumValue = document.getElementById("pageNumberInput").value;
+    const start = limit * (Number(pageNumValue) - 1);
+    searchParams.set("fileset_start", start)
+    window.location.href = path + "?" + searchParams.toString()
+  };
+</script>
+
 
 <h2>Actions</h2>
 <button class="button button--primary">Download object</button>

--- a/templates/object.html
+++ b/templates/object.html
@@ -119,13 +119,6 @@
 </details>
 {% endfor %}
 </div>
-<div
-  id="pagination-data"
-  data-url="{{ request.url }}"
-  data-limit="{{ filesets_page.limit }}"
-  data-total="{{ filesets_page.total_items }}"
->
-</div>
 {{ pagination(
   page_index=filesets_page.index,
   num_pages=filesets_page.total_pages,
@@ -136,8 +129,15 @@
   page_number_input_id='pageNumberInput',
   go_button_id='pageGoButton'
 ) }}
+<div
+  id="paginationData"
+  data-url="{{ request.url }}"
+  data-limit="{{ filesets_page.limit }}"
+  data-total="{{ filesets_page.total_items }}"
+>
+</div>
 <script>
-  const dataElem = document.getElementById("pagination-data");
+  const dataElem = document.getElementById("paginationData");
   const urlString = dataElem.dataset.url;
   const limit = Number(dataElem.dataset.limit);
   const total = Number(dataElem.dataset.total);
@@ -148,21 +148,24 @@
   const startKey = "fileset_start";
   const currentStart = Number(searchParams.get(startKey) ?? 0);
 
-  document.getElementById('pagePreviousButton').onclick = function() {
+  function goTo(path, searchParams) {
+    window.location.href = path + "?" + searchParams.toString();
+  }
+
+  document.getElementById("pagePreviousButton").onclick = function() {
     searchParams.set(startKey, currentStart - limit);
-    window.location.href = path + "?" + searchParams.toString();
+    goTo(path, searchParams);
   };
 
-  document.getElementById('pageNextButton').onclick = function() {
+  document.getElementById("pageNextButton").onclick = function() {
     searchParams.set(startKey, currentStart + limit);
-    window.location.href = path + "?" + searchParams.toString();
+    goTo(path, searchParams);
   };
 
-  document.getElementById('pageGoButton').onclick = function() {
+  document.getElementById("pageGoButton").onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
-    const start = limit * (Number(pageNumValue) - 1);
-    searchParams.set(startKey, start)
-    window.location.href = path + "?" + searchParams.toString()
+    searchParams.set(startKey, limit * (Number(pageNumValue) - 1))
+    goTo(path, searchParams);
   };
 </script>
 <h2>Actions</h2>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -1,4 +1,4 @@
-{% from 'macros/pagination.html' import pagination %}
+{% from 'macros/start_pagination.html' import start_pagination %}
 {% extends "base.html" %}
 {% set page_name = 'objects' %}
 {% set page_title = 'Objects' %}
@@ -88,55 +88,12 @@
   </tbody>
 </table>
 </div>
-{{ pagination(
-  page_index=page.index,
-  num_pages=page.total_pages,
-  previous_button_id='pagePreviousButton',
-  previous_button_disabled=page.previous_offset == -1,
-  next_button_id='pageNextButton',
-  next_button_disabled=page.next_offset == -1,
-  page_number_input_id='pageNumberInput',
-  go_button_id='pageGoButton'
+{{ start_pagination(
+  page=page,
+  url=request.url,
+  id_suffix="Objects",
+  start_key="start"
 ) }}
-<div
-  id="paginationData"
-  data-url="{{ request.url }}"
-  data-limit="{{ page.limit }}"
-  data-total="{{ page.total_items }}"
->
-</div>
-<script>
-  const dataElem = document.getElementById("paginationData");
-  const urlString = dataElem.dataset.url;
-  const limit = Number(dataElem.dataset.limit);
-  const total = Number(dataElem.dataset.total);
-
-  const url = new URL(urlString);
-  const path = url.pathname;
-  const searchParams = new URLSearchParams(url.search);
-  const startKey = "start";
-  const currentStart = Number(searchParams.get(startKey) ?? 0);
-
-  function goTo(path, searchParams) {
-    window.location.href = path + "?" + searchParams.toString();
-  }
-
-  document.getElementById("pagePreviousButton").onclick = function() {
-    searchParams.set(startKey, currentStart - limit);
-    goTo(path, searchParams);
-  };
-
-  document.getElementById("pageNextButton").onclick = function() {
-    searchParams.set(startKey, currentStart + limit);
-    goTo(path, searchParams);
-  };
-
-  document.getElementById("pageGoButton").onclick = function() {
-    const pageNumValue = document.getElementById("pageNumberInput").value;
-    searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
-    goTo(path, searchParams);
-  };
-</script>
 </div>
 </div>
 </div>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -135,7 +135,6 @@
     window.location.href = path + "?" + searchParams.toString()
   };
 </script>
-
 </div>
 </div>
 </div>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -129,7 +129,7 @@
         </span>
       </div>
       <div class="input-container">
-        <button id="pageGoButton" class="button--primary" data-url="{{ url_for('get_objects') }}">Go</button>
+        <button id="pageGoButton" class="button--primary">Go</button>
       </div>
     </div>
   </div>
@@ -149,13 +149,13 @@
     if (currentStart <= 0) return;
     searchParams.set("start", currentStart - limit > 0 ? currentStart - limit : 0);
     window.location.href = path + "?" + searchParams.toString();
-  }
+  };
 
   document.getElementById('pageNextButton').onclick = function() {
     if (currentStart + limit > total) return;
     searchParams.set("start", currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();
-  }
+  };
 
   document.getElementById('pageGoButton').onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -87,6 +87,77 @@
   </tbody>
 </table>
 </div>
+<div id="pagination">
+  <div id="data" data-url="{{ request.url }}" data-limit="{{ page.limit }}" data-total="{{ page.total_items }}"></div>
+  <div class="input-group-inline">
+    <div class="input-group-inline" style="float: left">
+      <div class="input-container mr-1">
+        <button id="pagePreviousButton" class="button--ghost">
+          <span class="material-symbols-rounded">chevron_backward</span>
+          <span>Previous</span>
+        </button>
+      </div>
+      <div class="input-container">
+        <button id="pageNextButton" class="button--ghost">
+          <span>Next</span>
+          <span class="material-symbols-rounded">chevron_right</span>
+        </button>
+      </div>
+    </div>
+    <div class="input-group-inline" style="float: right">
+      <div class="input-container mr-1">
+        <span>
+          Go to page&nbsp;
+          <input
+            type="number"
+            id="pageNumberInput"
+            name="number"
+            min="1"
+            max="{{ page.total_pages }}"
+            value="{{ page.index }}"
+            step="1"
+          />
+          of {{ page.total_pages }}
+        </span>
+      </div>
+      <div class="input-container">
+        <button id="pageGoButton" class="button--primary" data-url="{{ url_for('get_objects') }}">Go</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  const dataElem = document.getElementById("data");
+  const urlString = dataElem.dataset.url;
+  const limit = Number(dataElem.dataset.limit);
+  const total = Number(dataElem.dataset.total);
+
+  const url = new URL(urlString);
+  const path = url.pathname;
+  const searchParams = new URLSearchParams(url.search);
+  const currentStart = Number(searchParams.get("start") ?? 0);
+
+  document.getElementById('pagePreviousButton').onclick = function() {
+    if (currentStart <= 0) return;
+    searchParams.set("start", currentStart - limit > 0 ? currentStart - limit : 0);
+    window.location.href = path + "?" + searchParams.toString();
+  }
+
+  document.getElementById('pageNextButton').onclick = function() {
+    if (currentStart + limit > total) return;
+    searchParams.set("start", currentStart + limit);
+    window.location.href = path + "?" + searchParams.toString();
+  }
+
+  document.getElementById('pageGoButton').onclick = function() {
+    const pageNumValue = document.getElementById("pageNumberInput").value;
+    const start = limit * (Number(pageNumValue) - 1);
+    searchParams.set("start", start)
+    window.location.href = path + "?" + searchParams.toString()
+  };
+</script>
+
+</div>
 </div>
 </div>
 {% endblock %}

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -117,13 +117,11 @@
   const currentStart = Number(searchParams.get("start") ?? 0);
 
   document.getElementById('pagePreviousButton').onclick = function() {
-    if (currentStart <= 0) return;
     searchParams.set("start", currentStart - limit > 0 ? currentStart - limit : 0);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageNextButton').onclick = function() {
-    if (currentStart + limit > total) return;
     searchParams.set("start", currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();
   };

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -133,7 +133,7 @@
 
   document.getElementById("pageGoButton").onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
-    searchParams.set(startKey, limit * (Number(pageNumValue) - 1))
+    searchParams.set(startKey, limit * (Number(pageNumValue) - 1));
     goTo(path, searchParams);
   };
 </script>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -92,13 +92,21 @@
   <div class="input-group-inline">
     <div class="input-group-inline" style="float: left">
       <div class="input-container mr-1">
-        <button id="pagePreviousButton" class="button--ghost">
+        <button
+          id="pagePreviousButton"
+          class="button--ghost"
+          {% if page.previous_offset == -1 %} disabled {% endif %}
+        >
           <span class="material-symbols-rounded">chevron_backward</span>
           <span>Previous</span>
         </button>
       </div>
       <div class="input-container">
-        <button id="pageNextButton" class="button--ghost">
+        <button
+          id="pageNextButton"
+          class="button--ghost"
+          {% if page.next_offset == -1 %} disabled {% endif %}
+        >
           <span>Next</span>
           <span class="material-symbols-rounded">chevron_right</span>
         </button>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -1,3 +1,4 @@
+{% from 'macros/pagination.html' import pagination %}
 {% extends "base.html" %}
 {% set page_name = 'objects' %}
 {% set page_title = 'Objects' %}
@@ -87,55 +88,25 @@
   </tbody>
 </table>
 </div>
-<div id="pagination">
-  <div id="data" data-url="{{ request.url }}" data-limit="{{ page.limit }}" data-total="{{ page.total_items }}"></div>
-  <div class="input-group-inline">
-    <div class="input-group-inline" style="float: left">
-      <div class="input-container mr-1">
-        <button
-          id="pagePreviousButton"
-          class="button--ghost"
-          {% if page.previous_offset == -1 %} disabled {% endif %}
-        >
-          <span class="material-symbols-rounded">chevron_backward</span>
-          <span>Previous</span>
-        </button>
-      </div>
-      <div class="input-container">
-        <button
-          id="pageNextButton"
-          class="button--ghost"
-          {% if page.next_offset == -1 %} disabled {% endif %}
-        >
-          <span>Next</span>
-          <span class="material-symbols-rounded">chevron_right</span>
-        </button>
-      </div>
-    </div>
-    <div class="input-group-inline" style="float: right">
-      <div class="input-container mr-1">
-        <span>
-          Go to page&nbsp;
-          <input
-            type="number"
-            id="pageNumberInput"
-            name="number"
-            min="1"
-            max="{{ page.total_pages }}"
-            value="{{ page.index }}"
-            step="1"
-          />
-          of {{ page.total_pages }}
-        </span>
-      </div>
-      <div class="input-container">
-        <button id="pageGoButton" class="button--primary">Go</button>
-      </div>
-    </div>
-  </div>
+<div
+  id="pagination-data"
+  data-url="{{ request.url }}"
+  data-limit="{{ page.limit }}"
+  data-total="{{ page.total_items }}"
+>
 </div>
+{{ pagination(
+  page_index=page.index,
+  num_pages=page.total_pages,
+  previous_button_id='pagePreviousButton',
+  previous_button_disabled=page.previous_offset == -1,
+  next_button_id='pageNextButton',
+  next_button_disabled=page.next_offset == -1,
+  page_number_input_id='pageNumberInput',
+  go_button_id='pageGoButton'
+) }}
 <script>
-  const dataElem = document.getElementById("data");
+  const dataElem = document.getElementById("pagination-data");
   const urlString = dataElem.dataset.url;
   const limit = Number(dataElem.dataset.limit);
   const total = Number(dataElem.dataset.total);

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -88,13 +88,6 @@
   </tbody>
 </table>
 </div>
-<div
-  id="pagination-data"
-  data-url="{{ request.url }}"
-  data-limit="{{ page.limit }}"
-  data-total="{{ page.total_items }}"
->
-</div>
 {{ pagination(
   page_index=page.index,
   num_pages=page.total_pages,
@@ -105,8 +98,15 @@
   page_number_input_id='pageNumberInput',
   go_button_id='pageGoButton'
 ) }}
+<div
+  id="paginationData"
+  data-url="{{ request.url }}"
+  data-limit="{{ page.limit }}"
+  data-total="{{ page.total_items }}"
+>
+</div>
 <script>
-  const dataElem = document.getElementById("pagination-data");
+  const dataElem = document.getElementById("paginationData");
   const urlString = dataElem.dataset.url;
   const limit = Number(dataElem.dataset.limit);
   const total = Number(dataElem.dataset.total);
@@ -117,21 +117,24 @@
   const startKey = "start";
   const currentStart = Number(searchParams.get(startKey) ?? 0);
 
-  document.getElementById('pagePreviousButton').onclick = function() {
+  function goTo(path, searchParams) {
+    window.location.href = path + "?" + searchParams.toString();
+  }
+
+  document.getElementById("pagePreviousButton").onclick = function() {
     searchParams.set(startKey, currentStart - limit);
-    window.location.href = path + "?" + searchParams.toString();
+    goTo(path, searchParams);
   };
 
-  document.getElementById('pageNextButton').onclick = function() {
+  document.getElementById("pageNextButton").onclick = function() {
     searchParams.set(startKey, currentStart + limit);
-    window.location.href = path + "?" + searchParams.toString();
+    goTo(path, searchParams);
   };
 
-  document.getElementById('pageGoButton').onclick = function() {
+  document.getElementById("pageGoButton").onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
-    const start = limit * (Number(pageNumValue) - 1);
-    searchParams.set(startKey, start)
-    window.location.href = path + "?" + searchParams.toString()
+    searchParams.set(startKey, limit * (Number(pageNumValue) - 1))
+    goTo(path, searchParams);
   };
 </script>
 </div>

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -114,22 +114,23 @@
   const url = new URL(urlString);
   const path = url.pathname;
   const searchParams = new URLSearchParams(url.search);
-  const currentStart = Number(searchParams.get("start") ?? 0);
+  const startKey = "start";
+  const currentStart = Number(searchParams.get(startKey) ?? 0);
 
   document.getElementById('pagePreviousButton').onclick = function() {
-    searchParams.set("start", currentStart - limit > 0 ? currentStart - limit : 0);
+    searchParams.set(startKey, currentStart - limit);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageNextButton').onclick = function() {
-    searchParams.set("start", currentStart + limit);
+    searchParams.set(startKey, currentStart + limit);
     window.location.href = path + "?" + searchParams.toString();
   };
 
   document.getElementById('pageGoButton').onclick = function() {
     const pageNumValue = document.getElementById("pageNumberInput").value;
     const start = limit * (Number(pageNumValue) - 1);
-    searchParams.set("start", start)
+    searchParams.set(startKey, start)
     window.location.href = path + "?" + searchParams.toString()
   };
 </script>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass
+
 import pytest
 
-from dor.utils import Filter, FilterLabel, remove_parameter
+from dor.utils import Filter, FilterLabel, Page, remove_parameter
 
 
 @pytest.fixture
@@ -28,3 +30,59 @@ def test_filter_makes_label(parameters: dict[str, str]):
         remove_url="?alt_identifier=amjewess%3A&collection_alt_identifier=amjewess"
     )
     assert expected_label == filter.make_label(parameters)
+
+
+# Page
+
+@dataclass
+class DummyItem:
+    id: int
+    name: str
+
+
+@pytest.fixture
+def dummy_items() -> list[DummyItem]:
+    return [
+        DummyItem(id=0, name="A"),
+        DummyItem(id=1, name="B"),
+        DummyItem(id=2, name="C"),
+        DummyItem(id=3, name="D"),
+        DummyItem(id=4, name="E"),
+        DummyItem(id=5, name="F"),
+        DummyItem(id=6, name="G"),
+        DummyItem(id=7, name="H")
+    ]
+
+
+def test_page_sets_total_pages(dummy_items):
+    page = Page(total_items=len(dummy_items), offset=0, limit=2, items=dummy_items[0:2])
+
+    assert page.total_pages == 4
+
+
+def test_page_updates_offsets_in_middle_of_range(dummy_items: list[DummyItem]):
+    page = Page(total_items=len(dummy_items), offset=4, limit=2, items=dummy_items[4:6])
+
+    assert page.previous_offset == 2
+    assert page.next_offset == 6
+
+
+def test_page_updates_offsets_at_beginning_of_range(dummy_items: list[DummyItem]):
+    page = Page(total_items=len(dummy_items), offset=0, limit=2, items=dummy_items[0:2])
+
+    assert page.previous_offset == -1
+    assert page.next_offset == 2
+
+
+def test_page_updates_offsets_near_beginning_of_range(dummy_items: list[DummyItem]):
+    page = Page(total_items=len(dummy_items), offset=1, limit=2, items=dummy_items[1:3])
+
+    assert page.previous_offset == 0
+    assert page.next_offset == 3
+
+
+def test_page_updates_offsets_at_end_of_range(dummy_items: list[DummyItem]):
+    page = Page(total_items=len(dummy_items), offset=7, limit=2, items=dummy_items[7:])
+
+    assert page.previous_offset == 5
+    assert page.next_offset == -1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,7 +54,7 @@ def dummy_items() -> list[DummyItem]:
     ]
 
 
-def test_page_sets_total_pages(dummy_items):
+def test_page_sets_total_pages(dummy_items: list[DummyItem]):
     page = Page(total_items=len(dummy_items), offset=0, limit=2, items=dummy_items[0:2])
 
     assert page.total_pages == 4


### PR DESCRIPTION
This PR aims to resolve [DOR-88](https://mlit.atlassian.net/jira/software/projects/DOR/boards/93?jql=parent%20%3D%20DOR-81&selectedIssue=DOR-88). It introduces a pair of macros: `pagination`, which encapsulates the HTML part of pagination, and `start_pagination`, which wraps `pagination` and adds calculation and interactive behavior using Javascript. These "components" are then used on the object list and the fileset list (on the object detail page).

Resource(s)
- https://jinja.palletsprojects.com/en/stable/templates/#macros