### PR TITLE
rename PREMIS Events -> Events in sidebar

### DIFF
--- a/templates/partials/_side-nav.html
+++ b/templates/partials/_side-nav.html
@@ -5,7 +5,7 @@
       {'name': 'Collections', 'page': 'collections', 'url': '/admin/console/collections/'}, 
       {'name': 'Files', 'page': 'files', 'url': '/admin/console/files/'}, 
       {'name': 'Storage', 'page': 'storage', 'url': '/admin/console/storage/'}, 
-      {'name': 'PREMIS events', 'page': 'premis', 'url': '/admin/console/premis/'}, 
+      {'name': 'Events', 'page': 'premis', 'url': '/admin/console/events/'}, 
       {'name': 'Settings', 'page': 'settings', 'url': '/admin/console/settings/'}
       ] %} 
       <nav aria-label="Site navigation" class="side-nav">


### PR DESCRIPTION
In olden days, I'd have pushed to main (and production).